### PR TITLE
use new leaves only query field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='graphite_raintank',
-    version='0.1',
+    version='0.2',
     url='https://github.com/raintank/graphite_raintank',
     license='apache2',
     author='Anthony Woods',


### PR DESCRIPTION
our fork of graphite-api adds a leaves_only field to the query object. This lets us now optimize our queries  and to skip the rather expensive branch query when we dont need it.
