### PR TITLE
pass on users errors

### DIFF
--- a/graphite_raintank.py
+++ b/graphite_raintank.py
@@ -215,6 +215,10 @@ class RaintankFinder(object):
         }
         resp = requests.get(url, params=params, headers=headers)
         logger.debug('fetch_from_tank', url=url, status_code=resp.status_code, body=resp.text)
+        if resp.status_code == 400:
+            raise Exception("metric-tank said: %s" % resp.text)
+        if resp.status_code == 500:
+            raise Exception("metric-tank internal server error")
         dataMap = {}
         mergeSet = {}
         for result in resp.json():


### PR DESCRIPTION
- if MT said bad request, pass on the details to user
- if MT 500'd, just tell the user MT messed up, they don't need to know
  specifics

before this, we always try to parse json and in these case cases you typically get "couldn't parse json errors" without anything useful.

note: this still shows a full stack trace, not sure how to prevent that.
