### PR TITLE
search for metrics directly in metrictank, bypassing ES

### DIFF
--- a/pkg/Dockerfile
+++ b/pkg/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
  
-RUN apt-get update && apt-get install -y libcairo2 libffi6 python
+RUN apt-get update && apt-get install -y libcairo2 libffi6 python netcat-traditional
 RUN mkdir -p /etc/graphite-metrictank
 RUN mkdir -p /var/lib/graphite
 COPY docker/gunicorn_conf.py /etc/graphite-metrictank

--- a/pkg/build_all.sh
+++ b/pkg/build_all.sh
@@ -5,7 +5,7 @@ cd ${DIR}
 SOURCEDIR=$(readlink -e ${DIR}/..)
 BUILDDIR=${DIR}/build
 mkdir -p $BUILDDIR
-
+TARGETS=${1:-debian:wheezy debian:jessie ubuntu:trusty ubuntu:xenial centos:6 centos:7}
 build_target()
 {
 	DISTRO=$1
@@ -13,7 +13,7 @@ build_target()
 	docker run --rm -v $SOURCEDIR:/opt/graphite-raintank $DISTRO:$VERSION /opt/graphite-raintank/pkg/build.sh $DISTRO $VERSION
 }
 
-for target in debian:wheezy debian:jessie ubuntu:trusty ubuntu:xenial centos:6 centos:7; do
+for target in $TARGETS; do
 	_distro=${target%:*}
     _version=${target#*:}
     build_target $_distro $_version

--- a/pkg/common/graphite-metrictank/graphite-metrictank.yaml
+++ b/pkg/common/graphite-metrictank/graphite-metrictank.yaml
@@ -21,11 +21,7 @@ logging:
         - raw
       level: DEBUG
 raintank:
-  es:
-    url: http://localhost:9200/
-    index: metric
-    cache_ttl: 60
-    max_docs: 10000
+  cache_ttl: 60
   tank:
     url: http://localhost:6060/
 search_index: /var/lib/graphite/index


### PR DESCRIPTION
closes #33 

Instead of searching for series in ES, search directly in metrictank using metrictank's own index.
This ensures that graphite will continue to work regardless of MetricIndex type metrictank is using.
