### PR TITLE
Fix for hitcount function

### DIFF
--- a/graphite_metrictank.py
+++ b/graphite_metrictank.py
@@ -109,8 +109,8 @@ class RaintankFinder(object):
             pattern = query.pattern.replace("litmus", "worldping", 1)
 
         params = {
-            "query": pattern, 
-            "from": query.startTime, 
+            "query": pattern,
+            "from": query.startTime,
             "until": query.endTime,
             "format": "completer",
         }
@@ -156,7 +156,7 @@ class RaintankFinder(object):
         if maxDataPoints is not None:
             params['maxDataPoints'] = maxDataPoints
         pathMap = {}
-        for node in nodes:     
+        for node in nodes:
             target = node.reader.path
             if node.consolidateBy is not None:
                 target = "consolidateBy(%s,%s)" %(node.reader.path, node.consolidateBy)
@@ -197,6 +197,6 @@ class RaintankFinder(object):
                             step = end_time-start_time
                         else:
                             step = result["datapoints"][1][1] - result["datapoints"][0][1]
-                        time_info = (first, last, step)
+                        time_info = (first, last+step, step)
 
         return time_info, series


### PR DESCRIPTION
Default graphite-api whisper finder directly uses whisper library method to return timeseries data, in code of whisper python module there is line responsible for returning end boundary of series.
According to this line [#828](https://github.com/graphite-project/whisper/blob/master/whisper.py#L828) returned boundary should be greater from last data point by the value of default archive step. Returned value is used for calculation list indexes in hitcount method. This patch adds the step value and allows usage of hitcount function. This should fix issue #38  